### PR TITLE
Added frame padding to CMAC kernel

### DIFF
--- a/Ethernet/bd_cmac.tcl
+++ b/Ethernet/bd_cmac.tcl
@@ -378,8 +378,3 @@ assign_bd_address -target_address_space [get_bd_addr_spaces cmac_sync/s_axi] [ge
 validate_bd_design
 save_bd_design
 
-
-delete_bd_objs [get_bd_intf_nets S_AXIS_1] [get_bd_intf_nets frame_padding_M_AXIS] [get_bd_cells frame_padding]
-connect_bd_intf_net [get_bd_intf_ports S_AXIS] [get_bd_intf_pins acc_kernel_tx_cdc/S_AXIS]
-validate_bd_design
-save_bd_design

--- a/Ethernet/src/frame_padding.v
+++ b/Ethernet/src/frame_padding.v
@@ -72,7 +72,7 @@ module frame_padding (
 
     // Flag when a new frame starts
     always @(posedge S_AXI_ACLK) begin
-        if (S_AXI_ARESETN) begin
+        if (~S_AXI_ARESETN) begin
             new_frame = 1'b1;
         end
         else begin


### PR DESCRIPTION
Fixed reset of frame padding module and re-added it to CMAC BD. Tested with benchmark design which works.