### PR TITLE
Replace deprecated numpy aliases of builtin types with the actual types

### DIFF
--- a/Notebooks/vnx-benchmark-rtt-switch.ipynb
+++ b/Notebooks/vnx-benchmark-rtt-switch.ipynb
@@ -619,7 +619,7 @@
    "outputs": [],
    "source": [
     "freq = int(ol_w1.clock_dict['clock0']['frequency'])\n",
-    "rtt_usec = np.array(shape, dtype=np.float)\n",
+    "rtt_usec = np.array(shape, dtype=float)\n",
     "rtt_usec= rtt_cycles / freq  # convert to microseconds"
    ]
   },

--- a/Notebooks/vnx-benchmark-rtt.ipynb
+++ b/Notebooks/vnx-benchmark-rtt.ipynb
@@ -421,7 +421,7 @@
    "outputs": [],
    "source": [
     "freq = int(ol_w1.clock_dict['clock0']['frequency'])\n",
-    "rtt_usec = np.array(shape, dtype=np.float)\n",
+    "rtt_usec = np.array(shape, dtype=float)\n",
     "rtt_usec= rtt_cycles / freq  # convert to microseconds"
    ]
   },

--- a/Notebooks/vnx_utils.py
+++ b/Notebooks/vnx_utils.py
@@ -323,7 +323,7 @@ class NetworkLayer(DefaultIP):
             ("theirIP", np.unicode_, 16),
             ("theirPort", np.uint16),
             ("myPort", np.uint16),
-            ("valid", np.bool),
+            ("valid", bool),
         ]
     )
 


### PR DESCRIPTION
Updated vnx_util.py to use bool instead np.bool. Also did the same in the benchmark notebooks, but for float.

np.bool and some other aliases of builtin python types have been deprecated: https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated

This caused some errors with newer numpy versions.