### PR TITLE
Fix typo in Alveo U50 Vivado Part Number

### DIFF
--- a/Ethernet/bd_cmac.tcl
+++ b/Ethernet/bd_cmac.tcl
@@ -54,7 +54,7 @@ if {${projPart} eq "xcu55n-fsvh2892-2L-e"} {
       set interface_number 0
     }
   }
-} elseif {${projPart} eq "xcu50-fsvh2104-2L-e"} {
+} elseif {${projPart} eq "xcu50-fsvh2104-2-e"} {
   # Possible core_selection CMACE4_X0Y3 and CMACE4_X0Y4
   set gt_ref_clk 161.1328125
   set core_selection  CMACE4_X0Y3

--- a/Ethernet/package_cmac.tcl
+++ b/Ethernet/package_cmac.tcl
@@ -53,7 +53,7 @@ set path_to_tmp_project "./tmp_${suffix}"
 #get projPart
 source platform.tcl
 
-if {${projPart} eq "xcu50-fsvh2104-2L-e"} {
+if {${projPart} eq "xcu50-fsvh2104-2-e"} {
     if {$interface != 0} {
         catch {common::send_gid_msg -ssname BD::TCL -id 2041 -severity "ERROR" "Alveo U50 only has one interface (0)"}
         return 1

--- a/Ethernet/platform.tcl
+++ b/Ethernet/platform.tcl
@@ -8,7 +8,7 @@ set board [lindex $words 1]
 if {[string first "u55n" ${board}] != -1} {
     set projPart "xcu55n-fsvh2892-2L-e"
 } elseif {[string first "u50" ${board}] != -1} {
-    set projPart "xcu50-fsvh2104-2L-e"
+    set projPart "xcu50-fsvh2104-2-e"
 } elseif {[string first "u55c" ${board}] != -1} {
     set projPart "xcu55c-fsvh2892-2L-e"
 } elseif {[string first "u200" ${board}] != -1} {

--- a/NetLayers/platform.tcl
+++ b/NetLayers/platform.tcl
@@ -8,7 +8,7 @@ set board [lindex $words 1]
 if {[string first "u55n" ${board}] != -1} {
     set projPart "xcu55n-fsvh2892-2L-e"
 } elseif {[string first "u50" ${board}] != -1} {
-    set projPart "xcu50-fsvh2104-2L-e"
+    set projPart "xcu50-fsvh2104-2-e"
 } elseif {[string first "u55c" ${board}] != -1} {
     set projPart "xcu55c-fsvh2892-2L-e"
 } elseif {[string first "u200" ${board}] != -1} {


### PR DESCRIPTION
typo results in error when compiling for xilinx_u50_gen3x16_xdma_5_202210_1